### PR TITLE
通知設定のボタン(？)を押すと通知設定に飛ぶようにしました

### DIFF
--- a/app/src/main/java/com/example/runningavater/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/runningavater/settings/SettingsScreen.kt
@@ -1,6 +1,8 @@
 package com.example.runningavater.settings
 
+import android.content.Intent
 import android.net.Uri
+import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -17,13 +20,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -51,7 +51,10 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     val openAlertDialog = remember { mutableStateOf(false) }
-    var checked by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+        putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+    }
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -82,7 +85,7 @@ fun SettingsScreen(
             color = NuclearMango,
             modifier =
             Modifier
-                .padding(bottom = 40.dp)
+                .padding(bottom = 50.dp)
                 .clip(RoundedCornerShape(4.dp))
                 .background(GranulatedSugar)
                 .padding(horizontal = 22.dp),
@@ -92,7 +95,6 @@ fun SettingsScreen(
             modifier =
             Modifier
                 .padding(
-                    vertical = 10.dp,
                     horizontal = 5.dp
                 )
                 .fillMaxWidth()
@@ -163,13 +165,14 @@ fun SettingsScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    vertical = 33.dp,
+                    vertical = 63.dp,
                     horizontal = 5.dp
                 )
+                .height(60.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .background(GranulatedSugar)
-                .padding(vertical = 10.dp)
-                .clickable { openAlertDialog.value = true }
+                .clickable { openAlertDialog.value = true },
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 "目標歩数設定",
@@ -186,12 +189,12 @@ fun SettingsScreen(
             Modifier
                 .fillMaxWidth()
                 .padding(
-                    vertical = 33.dp,
                     horizontal = 5.dp
                 )
+                .height(60.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .background(GranulatedSugar)
-                .padding(vertical = 10.dp),
+                .clickable { context.startActivity(intent) },
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -203,10 +206,11 @@ fun SettingsScreen(
                     .padding(start = 16.dp)
                     .weight(1f),
             )
-            Switch(
-                checked = checked,
-                onCheckedChange = { checked = it },
-                modifier = Modifier.padding(end = 16.dp),
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowRight, contentDescription = "Profile",
+                modifier = Modifier
+                    .padding(end = 20.dp)
+                    .size(20.dp),
             )
         }
     }


### PR DESCRIPTION
<!--

タイトルをわかりやすい名前で入力しようね 🥸 🥸 🥸 🥸 🥸

-->

## やったこと
設定画面で通知設定の欄を押すとスマホの設定の通知画面に飛ぶようになりました！！！
<!--
- この PR で何をしたのか概要を書いてください〜
- 関連する issueがある場合は以下のように入力してください。(xxxはissueの番号)
-->

Close #xxx

## やってないこと
なし(強いて言えばスマホの設定に飛ぶよみたいな記述をアプリ内でしていない)
<!--
- このプルリクでやっていないことは何か？（無いなら「無し」で OK）
- 実装中に、これからは必要になるかもと感じた点を書いてくれてたら助かります！
-->

## スクリーンショット・動作確認



<video src = "https://github.com/user-attachments/assets/d21dad7a-2814-40c7-ac67-0d68b11ba69c" width = "300"></video>
<!--
* どのような動作確認を行って結果が得られたのか簡単に教えてください〜
* ファイルをアップして <img src="" width="300" /> と入力し、src をアップしたファイルのURLで置き換えると画像サイズを調整できますー
-->

## 自己評価

出来を 10 点満点で自己評価:

10 点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [ ] 心配なところがいくつかある。 <!-- 心配な点を下に書く -->
- [ ] あまり理解できていないが issue などに書いてあるとおり やった。
- [ ] その他（下に記入）

## その他

- レビュワーへの参考情報（気になった点や注意点などあれば〜）
