### PR TITLE
設定画面とDatastore連携。初期フローのアイコンを丸に。

### DIFF
--- a/app/src/main/java/com/example/runningavater/initialFlow/InitialFlow7.kt
+++ b/app/src/main/java/com/example/runningavater/initialFlow/InitialFlow7.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -100,11 +101,13 @@ fun InitialFlow7Screen(navController: NavHostController) {
                 if (imageUri != null) {
                     AsyncImage(
                         model = imageUri,
-                        contentDescription = null,
+                        contentDescription = "userIcon",
+                        contentScale = ContentScale.Crop,
                         modifier =
                         Modifier
-                            .offset((0.dp), (35.dp))
                             .size(220.dp)
+                            .offset((0.dp), (35.dp))
+                            .clip(CircleShape)
                             .clickable { launcher.launch("image/%") },
                     )
                 } else {
@@ -115,8 +118,8 @@ fun InitialFlow7Screen(navController: NavHostController) {
                         Modifier
                             .offset((0.dp), (35.dp))
                             .size(220.dp)
+                            .clickable { launcher.launch("image/%") }
                             .clip(CircleShape)
-                            .clickable { launcher.launch("image/%") },
                     )
                 }
                 TextField(

--- a/app/src/main/java/com/example/runningavater/settings/ProfileScreen.kt
+++ b/app/src/main/java/com/example/runningavater/settings/ProfileScreen.kt
@@ -135,7 +135,7 @@ fun ProfileScreen(
             model = ImageRequest
                 .Builder(LocalContext.current)
                 .data(iconToDisplay)
-                .build()
+                .build(),
         )
     }
     val keyboardController = LocalSoftwareKeyboardController.current


### PR DESCRIPTION
<!--

タイトルをわかりやすい名前で入力しようね 🥸 🥸 🥸 🥸 🥸

-->

## やったこと

<!--
- この PR で何をしたのか概要を書いてください〜
- 関連する issueがある場合は以下のように入力してください。(xxxはissueの番号)
-->

- 設定画面のアイコンと名前をDataStoreから引っ張ってくるようにしました(コードを書いたのが5日前なのでなんで放置してたか忘れたけど...)
- InitialFlowのフォルダから選択したアイコンが今までそのままのサイズだったけど丸に収まるようにリサイズした

Close #60 

## やってないこと

<!--
- このプルリクでやっていないことは何か？（無いなら「無し」で OK）
- 実装中に、これからは必要になるかもと感じた点を書いてくれてたら助かります！
-->

## スクリーンショット・動作確認

**ちゃんと変更が反映されてますね！！** ~~↓A型の人許して...↓~~
<img src = "https://github.com/user-attachments/assets/6ba50fa4-b1f8-4637-9521-ece33586e441" width = "300" />  <img src = "https://github.com/user-attachments/assets/0883673f-144d-4b7b-b15e-28ce7d8f0cf9" width = "300" />


<!--
* どのような動作確認を行って結果が得られたのか簡単に教えてください〜
* ファイルをアップして <img src="" width="300" /> と入力し、src をアップしたファイルのURLで置き換えると画像サイズを調整できますー
-->
ちゃんと丸になってますね☆
<img src = "https://github.com/user-attachments/assets/e9bf1a8e-5e94-41bf-a79d-6944d75bc836" width = "300" />  <img src = "https://github.com/user-attachments/assets/38ee9f14-caf4-456d-9f28-878580430591" width = "300" />

## 自己評価

出来を 10 点満点で自己評価:

1001(2) 点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [ ] 心配なところがいくつかある。 <!-- 心配な点を下に書く -->
- [ ] あまり理解できていないが issue などに書いてあるとおり やった。
- [ ] その他（下に記入）

## その他

- レビュワーへの参考情報（気になった点や注意点などあれば〜）
(めちゃくちゃ細長い画像だったらもしかしたら丸にならないかも...)